### PR TITLE
Bugfix error handling

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -16,14 +16,14 @@ class Footer extends Component {
               <li className='team-name'>Eyel</li>
               <ul className='team-social'>  
                 <li>
-                  <a href='https://github.com/csmordido' title="Click to access Eyel's Github page" target='_blank'>
+                  <a href='https://github.com/csmordido' title="Click to access Eyel's Github page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon 
                       icon={faGithub}
                       />
                   </a>
                 </li>
                 <li>
-                  <a href='https://twitter.com/eyel_mordido' title="Click to access Eyel's Twitter page" target='_blank'>
+                  <a href='https://twitter.com/eyel_mordido' title="Click to access Eyel's Twitter page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faTwitter}
                     />
@@ -35,14 +35,14 @@ class Footer extends Component {
               <li className='team-name'>Melissa</li>
               <ul className='team-social'>
                 <li>
-                  <a href='https://github.com/mel-ahls' title="Click to access Melissa's Github page" target='_blank'>
+                  <a href='https://github.com/mel-ahls' title="Click to access Melissa's Github page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faGithub}
                       />
                   </a>
                 </li>
                 <li>
-                  <a href='https://twitter.com/mel_ahls' title="Click to access Melissa's Twitter page" target='_blank'>
+                  <a href='https://twitter.com/mel_ahls' title="Click to access Melissa's Twitter page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faTwitter}
                     />
@@ -54,14 +54,14 @@ class Footer extends Component {
               <li className='team-name'>Robert</li>
               <ul className='team-social'>
                 <li>
-                  <a href='https://github.com/rduhig' title="Click to access Robert's Github page" target='_blank'>
+                  <a href='https://github.com/rduhig' title="Click to access Robert's Github page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faGithub}
                       />
                   </a>
                 </li>
                 <li>
-                  <a href='https://twitter.com/robert_duhig' title="Click to access Robert's Twitter page" target='_blank'>
+                  <a href='https://twitter.com/robert_duhig' title="Click to access Robert's Twitter page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faTwitter}
                     />
@@ -73,14 +73,14 @@ class Footer extends Component {
               <li className='team-name'>Taylor</li>
               <ul className='team-social'>
                 <li>
-                  <a href='https://github.com/QuercusTaliare' title="Click to access Taylor's Github page" target='_blank'>
+                  <a href='https://github.com/QuercusTaliare' title="Click to access Taylor's Github page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faGithub}
                       />
                   </a>
                 </li>
                 <li>
-                  <a href='https://twitter.com/taylorRdev' title="Click to access Taylor's Twitter page" target='_blank'>
+                  <a href='https://twitter.com/taylorRdev' title="Click to access Taylor's Twitter page" target='_blank' rel="noopener noreferrer">
                     <FontAwesomeIcon
                       icon={faTwitter}
                     />
@@ -92,8 +92,8 @@ class Footer extends Component {
         </section>
 
         <section className='attributions'>
-          <p>All films provided by <a href='https://www.themoviedb.org/documentation/api'>The Movie DB API</a></p>
-          <p>All icons provided by <a href='https://fontawesome.com/license'>Font Awesome</a> and <a href='http://www.freepik.com/' title='Freepik'>Freepik</a></p>
+          <p>All films provided by <a href='https://www.themoviedb.org/documentation/api' target='_blank' rel="noopener noreferrer">The Movie DB API</a></p>
+          <p>All icons provided by <a href='https://fontawesome.com/license' target="_blank" rel="noopener noreferrer">Font Awesome</a> and <a href='http://www.freepik.com/' title='Freepik' target="_blank" rel="noopener noreferrer">Freepik</a></p>
         </section>
         
       </footer>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -83,7 +83,7 @@ class Search extends Component {
     }).then( response => {
 
       if (!response.data.total_pages) {
-        this.setState({ hasError:true });
+        this.setState({ hasError: true });
       }
 
       response.data.results.forEach( film => {
@@ -102,8 +102,6 @@ class Search extends Component {
       this.setState({ hasError: true });
 
     });
-
-    // || !this.state.englishFilms.length
 
     this.setState({ userTextInput: '', englishFilms, isLoading: false });
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -81,20 +81,29 @@ class Search extends Component {
         include_adult: false,
       }
     }).then( response => {
+
+      if (!response.data.total_pages) {
+        this.setState({ hasError:true });
+      }
+
       response.data.results.forEach( film => {
+        
         if (film.original_language === 'en' && film.poster_path && englishFilms.length < 10) {
           englishFilms.push(film);
-        }
+        } 
+
+        // Scrolls to the list of English films
+        this.scrollToFilms();
+
       });
 
-      // Scrolls to the list of English films
-      this.scrollToFilms();
-
     }).catch( error => {
-      if (error && !this.state.englishFilms.length) {
-        this.setState({ hasError: true });
-      }
+
+      this.setState({ hasError: true });
+
     });
+
+    // || !this.state.englishFilms.length
 
     this.setState({ userTextInput: '', englishFilms, isLoading: false });
 


### PR DESCRIPTION
Search component - In the handleSubmit function, there is an axios call.  The changes I made are within the 'then' and 'catch' blocks. 

- In the 'then' block, at the top, I added an if statement that asked if there are no pages returned from the query then set the 'hasError' state to true.  This is for when the user types in gibberish to the search bar (like 'asdf'). That sort of query to the API does not throw an error, so that's why the API call never went to the 'catch' block.  Since it is directed into the 'then' block, that simple if statement will figure out if the response returned absolutely nothing first, and then carry on as usual afterwards.  I also moved the scrollToFilms() function within the forEach statement, allowing the scroll functionality to work only if some films were actually returned from the query.  

- In the 'catch' block, because of the changes above, I removed the if statement and was simply able to use the setState method here. This was because the only criteria for toggling the 'hasError' state was that there was an error, which is already why the API call would have entered this block in the first place.

Footer component
- Added rel="noopener noreferrer" to all the links, which improves the website's security. React will yell at you in the console about this, so that shouldn't pop up anymore.  